### PR TITLE
Attempt safe and fast buffer allocation

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -604,18 +604,13 @@ pub type FrameResult = Result<Option<Block>>;
 /// be anything, it is assumed they will be overwritten anyway.
 ///
 /// To use this function safely, the caller must overwrite all `new_len` bytes.
-unsafe fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> {
+fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> {
     if buffer.len() < new_len {
         // Previous data will be overwritten, so instead of resizing the
         // vector if it is too small, we might as well allocate a new one.
         if buffer.capacity() < new_len {
-            buffer = Vec::with_capacity(new_len);
+            buffer = vec![0; new_len];
         }
-
-        // We are going to fill the buffer anyway, so there is no point in
-        // initializing it with default values. This does mean that there could
-        // be garbage in the buffer, therefore this function is unsafe.
-        buffer.set_len(new_len);
     } else {
         buffer.truncate(new_len);
     }
@@ -655,10 +650,8 @@ impl<R: ReadBytes> FrameReader<R> {
         // decoded.
         let total_samples = header.channels() as usize * header.block_size as usize;
 
-        // Ensure the buffer is the right size to hold all samples, potentially
-        // allocating a new buffer without initializing the memory. From here
-        // on, we must be careful to overwrite each byte in the buffer.
-        buffer = unsafe { ensure_buffer_len(buffer, total_samples) };
+        // Ensure the buffer is the right size to hold all samples
+        buffer = ensure_buffer_len(buffer, total_samples);
 
         let bps = match header.bits_per_sample {
             Some(x) => x,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -602,8 +602,6 @@ pub type FrameResult = Result<Option<Block>>;
 /// A function to expand the length of a buffer, or replace the buffer altogether,
 /// so it can hold at least `new_len` elements. The contents of the buffer can
 /// be anything, it is assumed they will be overwritten anyway.
-///
-/// To use this function safely, the caller must overwrite all `new_len` bytes.
 fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> {
     if buffer.len() < new_len {
         // Previous data will be overwritten, so instead of resizing the


### PR DESCRIPTION
This should be the fastest way to safely initialize an intermediate buffer. `vec![value; lenght]` desugars into `Vec::from_elem()` which has a [fast path](https://github.com/rust-lang/rust/blob/9e3432447a9c6386443acdf731d488c159be3f66/src/liballoc/vec.rs#L1561-L1662) for value 0 that requests zeroed memory from the OS, and the OS zeroes memory on demand.

I have [converted](https://github.com/Shnatsel/claxon/commit/8e81a4905c250a89e940498c6d90597de2143396) the benchmarking suite to Criterion to get more accurate benchmarks, specifically so that I would be able to reliably detect <2% changes in performance which is impossible with regular cargo-bench. It also has an added bonus of working on stable Rust. 

According to the `testsamples.rs` benchmark, as well as measuring execution time of the bench_decode binary with [hyperfine](https://github.com/sharkdp/hyperfine), this change makes no difference in terms of performance. I have tested this both on `rustc 1.28.0 (9634041f0 2018-07-30)` and `rustc 1.30.0-nightly (d767ee116 2018-08-15)` with identical results.

However, the performance difference between Claxon master and libflac 1.3.1 is 1.44, not 1.13 as advertised in README.md; it is possible that on my machine the execution is bottlenecked elsewhere, and I would not notice performance degradation caused by this PR. So please run this through your benchmarking setup before merging.