### PR TITLE
More portable benchmarking script

### DIFF
--- a/tools/benchmark_against_libflac.sh
+++ b/tools/benchmark_against_libflac.sh
@@ -32,12 +32,12 @@ for i in {1..11}; do
     # overwrite.
     rm -f testsamples/extra/*.wav
     echo -n "[libflac]"
-    $(which time) --format="%e" --append --output /tmp/bench_times_libflac.dat \
+    env time --format="%e" --append --output /tmp/bench_times_libflac.dat \
         flac -d testsamples/extra/*.flac 2> /dev/null
 
     rm -f testsamples/extra/*.wav
     echo -en "\b\b\b\b\b\b\b\b\b[Claxon] \b"
-    $(which time) --format="%e" --append --output /tmp/bench_times_claxon.dat \
+    env time --format="%e" --append --output /tmp/bench_times_claxon.dat \
         target/release/examples/decode testsamples/extra/*.flac > /dev/null
 
     echo -e "\b\b\b\b\b\b\b\b[done]  "

--- a/tools/benchmark_against_libflac.sh
+++ b/tools/benchmark_against_libflac.sh
@@ -32,12 +32,12 @@ for i in {1..11}; do
     # overwrite.
     rm -f testsamples/extra/*.wav
     echo -n "[libflac]"
-    /bin/time --format="%e" --append --output /tmp/bench_times_libflac.dat \
+    $(which time) --format="%e" --append --output /tmp/bench_times_libflac.dat \
         flac -d testsamples/extra/*.flac 2> /dev/null
 
     rm -f testsamples/extra/*.wav
     echo -en "\b\b\b\b\b\b\b\b\b[Claxon] \b"
-    /bin/time --format="%e" --append --output /tmp/bench_times_claxon.dat \
+    $(which time) --format="%e" --append --output /tmp/bench_times_claxon.dat \
         target/release/examples/decode testsamples/extra/*.flac > /dev/null
 
     echo -e "\b\b\b\b\b\b\b\b[done]  "


### PR DESCRIPTION
Look up system-wide `time` binary instead of hardcoding it to /bin/time; e.g. on Ubuntu it's /usr/bin/time. This made the .sh script work for me.

To get benchmarking working I also had to exclude p0.flac and p1.flac sample files from archive.org because Claxon benchmarking program was panicking on decoding them: 

 * `thread 'main' panicked at 'assertion failed: reader.streaminfo().channels == 2', examples/decode.rs:25:5` for p0
 * `thread 'main' panicked at 'assertion failed: reader.streaminfo().bits_per_sample == 16', examples/decode.rs:24:5` for p1.

For me this custom R thing is way more trouble than it's worth and I'll just stick to `hyperfine "target/release/examples/decode testsamples/extra/*.flac" "flac -fd testsamples/extra/*.flac"` which does exactly the same in Rust and without custom scripts. But I thought I'd submit the fix anyway.