### PR TITLE
[safety-dance] Reduce some unsound usages of unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ documentation = "https://docs.rs/claxon"
 [badges]
 travis-ci = { repository = "ruuda/claxon", branch = "v0.4.2" }
 
+[dependencies]
+uninit = "0.1.0"
+
 [dev-dependencies]
 hound    = "3.0"
 mp4parse = "0.8"

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -135,10 +135,6 @@ impl<R: ReadBytes> ReadBytes for Crc8Reader<R> {
         }
     }
 
-    fn read_into(&mut self, _buffer: &mut [u8]) -> io::Result<()> {
-        panic!("CRC reader does not support read_into.");
-    }
-
     fn skip(&mut self, _amount: u32) -> io::Result<()> {
         panic!("CRC reader does not support skip, it does not compute CRC over skipped data.");
     }
@@ -165,10 +161,6 @@ impl<R: ReadBytes> ReadBytes for Crc16Reader<R> {
             Ok(None) => Ok(None),
             Err(err) => Err(err),
         }
-    }
-
-    fn read_into(&mut self, _buffer: &mut [u8]) -> io::Result<()> {
-        panic!("CRC reader does not support read_into.");
     }
 
     fn skip(&mut self, _amount: u32) -> io::Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::IoError(ref err) => Some(err),
             Error::FormatError(_) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@
 
 #![warn(missing_docs)]
 
+extern crate uninit;
+
 use std::fs;
 use std::io;
 use std::mem;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,6 +11,8 @@ use error::{Error, Result, fmt_err};
 use input::ReadBytes;
 use std::str;
 use std::slice;
+use uninit::VecExtendFromReader;
+use uninit::ReadIntoUninit;
 
 #[derive(Clone, Copy)]
 struct MetadataBlockHeader {
@@ -189,7 +191,7 @@ impl<'a> Iterator for GetTag<'a> {
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
         // This import is actually required on Rust 1.13.
-        #[allow(unused_imports)]
+        #[allow(deprecated, unused_imports)]
         use std::ascii::AsciiExt;
 
         while self.index < self.vorbis_comments.len() {
@@ -206,7 +208,7 @@ impl<'a> Iterator for GetTag<'a> {
 }
 
 #[inline]
-fn read_metadata_block_header<R: ReadBytes>(input: &mut R) -> Result<MetadataBlockHeader> {
+fn read_metadata_block_header<R: ReadIntoUninit + ReadBytes>(input: &mut R) -> Result<MetadataBlockHeader> {
     let byte = try!(input.read_u8());
 
     // The first bit specifies whether this is the last block, the next 7 bits
@@ -236,7 +238,7 @@ fn read_metadata_block_header<R: ReadBytes>(input: &mut R) -> Result<MetadataBlo
 /// metadata blocks including their header verbatim in packets. This function
 /// can be used to decode that raw data.
 #[inline]
-pub fn read_metadata_block_with_header<R: ReadBytes>(input: &mut R)
+pub fn read_metadata_block_with_header<R: ReadIntoUninit + ReadBytes>(input: &mut R)
                                                      -> Result<MetadataBlock> {
   let header = try!(read_metadata_block_header(input));
   read_metadata_block(input, header.block_type, header.length)
@@ -253,7 +255,7 @@ pub fn read_metadata_block_with_header<R: ReadBytes>(input: &mut R)
 /// a “FLAC Specific Box” which contains the block type and the raw data. This
 /// function can be used to decode that raw data.
 #[inline]
-pub fn read_metadata_block<R: ReadBytes>(input: &mut R,
+pub fn read_metadata_block<R: ReadIntoUninit + ReadBytes>(input: &mut R,
                                          block_type: u8,
                                          length: u32)
                                          -> Result<MetadataBlock> {
@@ -313,7 +315,7 @@ pub fn read_metadata_block<R: ReadBytes>(input: &mut R,
     }
 }
 
-fn read_streaminfo_block<R: ReadBytes>(input: &mut R) -> Result<StreamInfo> {
+fn read_streaminfo_block<R: ReadIntoUninit + ReadBytes>(input: &mut R) -> Result<StreamInfo> {
     let min_block_size = try!(input.read_be_u16());
     let max_block_size = try!(input.read_be_u16());
 
@@ -348,7 +350,7 @@ fn read_streaminfo_block<R: ReadBytes>(input: &mut R) -> Result<StreamInfo> {
 
     // Next are 128 bits (16 bytes) of MD5 signature.
     let mut md5sum = [0u8; 16];
-    try!(input.read_into(&mut md5sum));
+    try!(input.read_exact(&mut md5sum));
 
     // Lower bounds can never be larger than upper bounds. Note that 0 indicates
     // unknown for the frame size. Also, the block size must be at least 16.
@@ -394,7 +396,13 @@ fn read_streaminfo_block<R: ReadBytes>(input: &mut R) -> Result<StreamInfo> {
     Ok(stream_info)
 }
 
-fn read_vorbis_comment_block<R: ReadBytes>(input: &mut R, length: u32) -> Result<VorbisComment> {
+fn read_vorbis_comment_block<R> (
+    mut input: R,
+    length: u32,
+) -> Result<VorbisComment>
+where
+    R : ReadIntoUninit + ReadBytes,
+{
     if length < 8 {
         // We expect at a minimum a 32-bit vendor string length, and a 32-bit
         // comment count.
@@ -424,13 +432,9 @@ fn read_vorbis_comment_block<R: ReadBytes>(input: &mut R, length: u32) -> Result
     // 32-bit vendor string length, and comment count.
     let vendor_len = try!(input.read_le_u32());
     if vendor_len > length - 8 { return fmt_err("vendor string too long") }
-    let mut vendor_bytes = Vec::with_capacity(vendor_len as usize);
 
-    // We can safely set the lenght of the vector here; the uninitialized memory
-    // is not exposed. If `read_into` succeeds, it will have overwritten all
-    // bytes. If not, an error is returned and the memory is never exposed.
-    unsafe { vendor_bytes.set_len(vendor_len as usize); }
-    try!(input.read_into(&mut vendor_bytes));
+    let mut vendor_bytes = Vec::new();
+    try!(vendor_bytes.extend_from_reader(vendor_len as usize, &mut input));
     let vendor = try!(String::from_utf8(vendor_bytes));
 
     // Next up is the number of comments. Because every comment is at least 4
@@ -456,9 +460,8 @@ fn read_vorbis_comment_block<R: ReadBytes>(input: &mut R, length: u32) -> Result
         }
 
         // For the same reason as above, setting the length is safe here.
-        let mut comment_bytes = Vec::with_capacity(comment_len as usize);
-        unsafe { comment_bytes.set_len(comment_len as usize); }
-        try!(input.read_into(&mut comment_bytes));
+        let mut comment_bytes = Vec::new();
+        try!(comment_bytes.extend_from_reader(comment_len as usize, &mut input));
 
         bytes_left -= comment_len;
 
@@ -494,7 +497,7 @@ fn read_vorbis_comment_block<R: ReadBytes>(input: &mut R, length: u32) -> Result
     Ok(vorbis_comment)
 }
 
-fn read_padding_block<R: ReadBytes>(input: &mut R, length: u32) -> Result<()> {
+fn read_padding_block<R: ReadIntoUninit + ReadBytes>(input: &mut R, length: u32) -> Result<()> {
     // The specification dictates that all bits of the padding block must be 0.
     // However, the reference implementation does not issue an error when this
     // is not the case, and frankly, when you are going to skip over these
@@ -503,10 +506,19 @@ fn read_padding_block<R: ReadBytes>(input: &mut R, length: u32) -> Result<()> {
     Ok(try!(input.skip(length)))
 }
 
-fn read_application_block<R: ReadBytes>(input: &mut R, length: u32) -> Result<(u32, Vec<u8>)> {
-    if length < 4 {
-        return fmt_err("application block length must be at least 4 bytes")
-    }
+fn read_application_block<R> (
+    input: &mut R,
+    length: u32,
+) -> Result<(u32, Vec<u8>)>
+where
+    R : ReadIntoUninit + ReadBytes,
+{
+    let length_minus_four = match (length as usize).checked_sub(4) {
+        | Some(result) => result,
+        | _ => {
+            return fmt_err("application block length must be at least 4 bytes");
+        },
+    };
 
     // Reject large application blocks to avoid memory-based denial-
     // of-service attacks. See also the more elaborate motivation in
@@ -523,9 +535,8 @@ fn read_application_block<R: ReadBytes>(input: &mut R, length: u32) -> Result<(u
     // uninitialized memory is never exposed: read_into will either fill the
     // buffer completely, or return an err, in which case the memory is not
     // exposed.
-    let mut data = Vec::with_capacity(length as usize - 4);
-    unsafe { data.set_len(length as usize - 4); }
-    try!(input.read_into(&mut data));
+    let mut data = Vec::new();
+    try!(data.extend_from_reader(length_minus_four, input));
 
     Ok((id, data))
 }
@@ -536,7 +547,7 @@ fn read_application_block<R: ReadBytes>(input: &mut R, length: u32) -> Result<(u
 /// byte of a metadata block header. This means that the iterator will yield at
 /// least a single value. If the iterator ever yields an error, then no more
 /// data will be read thereafter, and the next value will be `None`.
-pub struct MetadataBlockReader<R: ReadBytes> {
+pub struct MetadataBlockReader<R: ReadIntoUninit + ReadBytes> {
     input: R,
     done: bool,
 }
@@ -544,7 +555,7 @@ pub struct MetadataBlockReader<R: ReadBytes> {
 /// Either a `MetadataBlock` or an `Error`.
 pub type MetadataBlockResult = Result<MetadataBlock>;
 
-impl<R: ReadBytes> MetadataBlockReader<R> {
+impl<R: ReadIntoUninit + ReadBytes> MetadataBlockReader<R> {
     /// Creates a metadata block reader that will yield at least one element.
     pub fn new(input: R) -> MetadataBlockReader<R> {
         MetadataBlockReader {
@@ -562,7 +573,7 @@ impl<R: ReadBytes> MetadataBlockReader<R> {
     }
 }
 
-impl<R: ReadBytes> Iterator for MetadataBlockReader<R> {
+impl<R: ReadIntoUninit + ReadBytes> Iterator for MetadataBlockReader<R> {
     type Item = MetadataBlockResult;
 
     #[inline]


### PR DESCRIPTION
[![safety-dance](https://raw.githubusercontent.com/rust-secure-code/safety-dance/master/img/safety-dance.png)](https://github.com/rust-secure-code/safety-dance)

(This is currently a WIP PR, for other members of `safety-dance` to help audit and improve the code)

This PR aims to tackle the issues raised in https://github.com/rust-secure-code/safety-dance/issues/4

Although the author had done a great job with only few instances of `unsafe` usage, and all quite well documented / justified, it turns out that the usage of unininitalized bytes has currently **no defined behavior** in Rust. Instead, the [`MaybeUninit`](https://doc.rust-lang.org/beta/std/mem/union.MaybeUninit.html) abstraction can be used, to safely handle uninitialized memory. Sadly, the `Read` trait of the `std` library does not yet offer an API to work with `MaybeUninit`.

Hence the usage of a helper crate, [`::uninit`](https://docs.rs/uninit), which provides precisely these zero-cost sound constructs.

  - the only thing is that for [`::uninit::ReadIntoUninit`](https://docs.rs/uninit/0.1.0/uninit/trait.ReadIntoUninit.html) to be usable with the custom reader of the crate, this `unsafe` trait has been required to be (re)implemented, resulting in some other `unsafe` instances. However, these `unsafe` instances are more of a formality (they aim to guard against a malicious implementation of the trait, which is not the case here).

  - so besides these 3 sound usages of `unsafe` for the `ReadIntoUninit` `impl`, **the other `unsafe` blocks have been _defused_**, except for two very well documented and justified cases of `unchecked` indexing, that I have therefore let be (I consider them sound).

___

Sadly, I have not been able to run the unit tests because some files are not in the repository. So I haven't been able to benchmark the impact of these changes 😕 