### PR TITLE
Derive PartialEq for StreamInfo and SeekPoint

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -20,7 +20,7 @@ struct MetadataBlockHeader {
 }
 
 /// The streaminfo metadata block, with important information about the stream.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StreamInfo {
     // TODO: "size" would better be called "duration" for clarity.
     /// The minimum block size (in inter-channel samples) used in the stream.
@@ -54,7 +54,7 @@ pub struct StreamInfo {
 }
 
 /// A seek point in the seek table.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SeekPoint {
     /// Sample number of the first sample in the target frame, or 2<sup>64</sup> - 1 for a placeholder.
     pub sample: u64,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -20,7 +20,7 @@ struct MetadataBlockHeader {
 }
 
 /// The streaminfo metadata block, with important information about the stream.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct StreamInfo {
     // TODO: "size" would better be called "duration" for clarity.
     /// The minimum block size (in inter-channel samples) used in the stream.
@@ -54,7 +54,7 @@ pub struct StreamInfo {
 }
 
 /// A seek point in the seek table.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct SeekPoint {
     /// Sample number of the first sample in the target frame, or 2<sup>64</sup> - 1 for a placeholder.
     pub sample: u64,


### PR DESCRIPTION
I'm writing a library that writes FLAC file headers and would love to have an easy test to assert that what I wrote out (this library's StreamInfo header) matches what this library reads back, so having PartialEq be implemented here would be helpful.